### PR TITLE
Add remaining ocean skull token implementation

### DIFF
--- a/src/box_hooks.c
+++ b/src/box_hooks.c
@@ -424,6 +424,7 @@ RECOMP_PATCH void EnBox_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList
                     gSPDisplayList((*gfx)++, &heartChestBaseDL);
                     return;
                 case GI_TRUE_SKULL_TOKEN:
+                case GI_OCEAN_SKULL_TOKEN:
                     gSPDisplayList((*gfx)++, &spiderChestBaseDL);
                     return;
                 case GI_KEY_BOSS:
@@ -460,6 +461,7 @@ RECOMP_PATCH void EnBox_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList
                     gSPDisplayList((*gfx)++, &heartChestLidDL);
                     return;
                 case GI_TRUE_SKULL_TOKEN:
+                case GI_OCEAN_SKULL_TOKEN:
                     gSPDisplayList((*gfx)++, &spiderChestLidDL);
                     return;
                 case GI_KEY_BOSS:

--- a/src/play_main_hooks.c
+++ b/src/play_main_hooks.c
@@ -344,7 +344,7 @@ void update_rando(PlayState* play) {
                 randoItemGive(GI_BOMBCHUS_20);
             }
 
-            gSaveContext.save.saveInfo.skullTokenCount &= 0xFFFF;
+            // gSaveContext.save.saveInfo.skullTokenCount &= 0xFFFF;
             gSaveContext.save.saveInfo.skullTokenCount |= rando_has_item(GI_TRUE_SKULL_TOKEN) << 0x10;
             gSaveContext.save.saveInfo.skullTokenCount |= rando_has_item(GI_OCEAN_SKULL_TOKEN);
 
@@ -367,6 +367,7 @@ void update_rando(PlayState* play) {
                         case GI_POTION_RED_BOTTLE:
                         case GI_CHATEAU_BOTTLE:
                         case GI_TRUE_SKULL_TOKEN:
+                        case GI_OCEAN_SKULL_TOKEN:
                             continue;
                     }
                     if (gi == GI_HEART_CONTAINER || gi == GI_HEART_PIECE) {


### PR DESCRIPTION
Integrates Ocean Tokens into [skulltula_token_hooks.c](https://github.com/RecompRando/MMRecompRando/blob/main/src/skulltula_token_hooks.c) (mostly untested though, due to disabling randomized tokens not working in the apworld). Also fixes its count in its message.

Also adds Ocean Tokens to CAMC and fixes the count doubling on reset.